### PR TITLE
Update preprocPair_with_inlineBC.py

### DIFF
--- a/scripts/python/preprocPair_with_inlineBC.py
+++ b/scripts/python/preprocPair_with_inlineBC.py
@@ -31,7 +31,7 @@ class convertApp:
         self.verbose = verbose
         try:
             # read in barcode sequences
-            bcTable = barcodeTable(barcodesFile)
+            bcTable = barcodeTable(barcodesFile, i1_rc=False)
             if self.verbose:
                 sys.stdout.write("barcode table length: %s\n" % bcTable.getLength())
 


### PR DESCRIPTION
notes:
_The problem was:_ the barcodeTable class has i1_rc=True as default, so it is searching your R1 for the reverse complement of the barcode. Add i1_rc=False and barcodes are searched with the correct orientation. 

When this change was made ~90% of reads in the test file with 238 reads (from beginning of illumina file) passed, and a slightly greater proportion of reads passed on our new test file of 1k reads from the middle of the .fastq file. 
